### PR TITLE
#7 Re-add Go string format placeholder

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -555,6 +555,13 @@
       }
     },
     {
+      "name": "[Go] String Format Placeholder",
+      "scope": "source.go constant.other.placeholder.go",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
       "name": "[Java](JavaDoc) Comment Block Documentation HTML Entities",
       "scope": "source.java comment.block.documentation.javadoc punctuation.definition.entity.html",
       "settings": {


### PR DESCRIPTION
Seems this vanished in the switch from .tmTheme format to a JSON file.