### PR TITLE
Improved "CodeLens" (reference hint) foreground

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -47,7 +47,7 @@
     "editorWarning.border": "#ebcb8b00",
     "editorBracketMatch.background": "#2e344000",
     "editorBracketMatch.border": "#88c0d0",
-    "editorCodeLens.foreground": "#d8dee9",
+    "editorCodeLens.foreground": "#4c566a",
     "editorGroup.background": "#2e3440",
     "editorGroup.border": "#3b425200",
     "editorGroup.dropBackground": "#2e3440",


### PR DESCRIPTION
> Closes #33

*CodeLenses* are hints to show references in the code for a specific variable/constant/entity. This change adjusts the foreground color to match comments to make it less disturbing and to distinguish it from the actual code.

---

\cc @yurlovm