### PR TITLE
Distinguish CSS property color from HTML tags

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -624,7 +624,7 @@
       "name": "[CSS] Support Type Property Name",
       "scope": "source.css support.type.property-name",
       "settings": {
-        "foreground": "#81A1C1"
+        "foreground": "#D8DEE9"
       }
     },
     {


### PR DESCRIPTION
> Closes #52

The color of CSS properties has been the same as HTML tags making it hard to distinguish between both. This PR changes the color of CSS properties to `nord4`.

![gh-53-scrot-preview](https://user-images.githubusercontent.com/7836623/31055755-de2428fa-a6c7-11e7-9aeb-b1534d8e634d.png)

