### PR TITLE
Make Perl sigils the same color as variables

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -987,6 +987,13 @@
       }
     },
     {
+      "name": "[Perl] Perl Sigils",
+      "scope": "source.perl punctuation.definition.variable",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
       "name": "[PHP] Meta Function-Call Object",
       "scope": [
         "source.php meta.function-call",


### PR DESCRIPTION
This is consistent with how sigils work in the vim version of Nord, and less distracting than having a separate color for the sigils which are actually part of the variable.