### PR TITLE
Add underline to links in markdown

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -938,6 +938,13 @@
       }
     },
     {
+      "name": "[Markdown] Markup Link",
+      "scope": "text.html.markdown markup.underline.link",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
       "name": "[Markdown] Markup List Numbered/Unnumbered",
       "scope": "text.html.markdown beginning.punctuation.definition.list",
       "settings": {


### PR DESCRIPTION
While I was verifying this issue in VS Code: https://github.com/Microsoft/vscode/issues/50382,

I found Nord does not add a underline to links in Markdown. However, VS Code would underline markdown links. This causes inconsistency:

![1](https://user-images.githubusercontent.com/4033249/40806523-ad98a2d8-64d6-11e8-8efe-7d70b8140e2a.gif)

If you add the following setting:

```json
  "editor.tokenColorCustomizations": {
    "textMateRules": [
      {
        "scope": "markup.underline.link",
        "settings": {
          "fontStyle": "underline"
        }
      }
    ]
  }
```

![2](https://user-images.githubusercontent.com/4033249/40806603-e176d7dc-64d6-11e8-9965-666f59314abd.gif)

That is because VS Code's tokenizer is much faster than the linkifying in markdown, so as you are typing, the whole link is immediately recognized as `markup.underline.link` and given underline, and this glitch would disappear.