### PR TITLE
Use nord4 for [JavaScript] Variable Other Object

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -842,7 +842,7 @@
       "name": "[JavaScript] Variable Other Object",
       "scope": "source.js meta.var.expr variable.other.object",
       "settings": {
-        "foreground": "#8FBCBB"
+        "foreground": "#D8DEE9"
       }
     },
     {


### PR DESCRIPTION
Hi there.

I noticed a little inconsistency in js object coloring. I believe nord4 should be used within the already existing scope selector here?
  
For reference, here is how it used to look like and how it looks now.

Notice both the `styles` object and the nested object properties.

<img width="781" alt="ss-before" src="https://user-images.githubusercontent.com/20142959/42297115-f21f7dd2-7fca-11e8-85ca-fefec99f89d4.png">
<img width="781" alt="ss-after" src="https://user-images.githubusercontent.com/20142959/42297116-f22b5fa8-7fca-11e8-9668-c2cd4f500da1.png">

What do you think?