### PR TITLE
fix: editor groups border can't be transparent

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -50,7 +50,7 @@
     "editorBracketMatch.border": "#88c0d0",
     "editorCodeLens.foreground": "#4c566a",
     "editorGroup.background": "#2e3440",
-    "editorGroup.border": "#3b425200",
+    "editorGroup.border": "#3b425201",
     "editorGroup.dropBackground": "#3b425299",
     "editorGroupHeader.noTabsBackground": "#2e3440",
     "editorGroupHeader.tabsBackground": "#2e3440",


### PR DESCRIPTION
Fix #98 tab moving in split view.

Field ```editorGroup.border``` can't be (well it can but it breaks some things) because [vscode splitview](https://github.com/Microsoft/vscode/blob/master/src/vs/base/browser/ui/splitview/splitview.ts#L164) remove separator class.
I've changed its alpha to 1% which is still not visible for human eye but fix this issue.