### PR TITLE
Decrease opacity for peek view match highlighting

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -160,7 +160,7 @@
     "peekView.border": "#4c566a",
     "peekViewEditor.background": "#2e3440",
     "peekViewEditorGutter.background": "#2e3440",
-    "peekViewEditor.matchHighlightBackground": "#88c0d0cc",
+    "peekViewEditor.matchHighlightBackground": "#88c0d04d",
     "peekViewResult.background": "#2e3440",
     "peekViewResult.fileForeground": "#88c0d0",
     "peekViewResult.lineForeground": "#d8dee966",


### PR DESCRIPTION
> Resolves #99

Decreased the opacity for peek view match highlighting. It was too bright that made it almost impossible to read the underlying text. This has been improved by decreasing the opacity of the used color (`nord8`) to 30%.

<p align="center"><strong>Before</strong><br /><img src="https://user-images.githubusercontent.com/4033249/44305931-3e63ee80-a339-11e8-91e3-ad40ccbbe98e.png" /></p>

<p align="center"><strong>After</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54864866-76af2d80-4d5d-11e9-9800-37fb5c7e10dc.png" /></p>