### PR TITLE
Improve function parameter highlighting in Python

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -1024,7 +1024,7 @@
     },
     {
       "name": "[Python] Function Call",
-      "scope": ["source.python meta.function-call", "source.python meta.function-call.generic"],
+      "scope": "source.python meta.function-call.generic",
       "settings": {
         "foreground": "#88C0D0"
       }


### PR DESCRIPTION
> Resolves #108

Improved the highlighting for function parameters in Python that were previously colorized with the same color like the function itself (`nord8`) instead of `nord4`.
This has been improved by removing the too generic scope `meta.function-call` from the `source.python` scope.

<p align="center"><strong>Before</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54865125-17ebb300-4d61-11e9-8f59-1f5c37795195.png" /></p>

<p align="center"><strong>After</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54865128-23d77500-4d61-11e9-8c67-3acff0ed487f.png" /></p>