### PR TITLE
Improve interpolated string literals

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -839,9 +839,13 @@
     },
     {
       "name": "[JavaScript] String Template Literals Punctuation",
-      "scope": "source.js string.template punctuation.definition.template-expression",
+      "scope": [
+        "source.js string.quoted.template punctuation.quasi.element.begin",
+        "source.js string.quoted.template punctuation.quasi.element.end",
+        "source.js string.template punctuation.definition.template-expression"
+      ],
       "settings": {
-        "foreground": "#5E81AC"
+        "foreground": "#81A1C1"
       }
     },
     {

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -849,6 +849,13 @@
       }
     },
     {
+      "name": "[JavaScript] Interpolated String Template Punctuation Functions",
+      "scope": "source.js string.quoted.template meta.method-call.with-arguments",
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
       "name": "[JavaScript] String Template Literal Variable",
       "scope": [
         "source.js string.template meta.template.expression support.variable.property",


### PR DESCRIPTION
> Resolves #106

Improved the color for function braces in string templates to use`nord6` instead of `nord14`. Also begin and end characters of an interpolated string literal `${}` are now colorized as keyword (`nord9`) for better visual distinction.

<p align="center"><strong>Before</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54867234-298f8380-4d7e-11e9-820f-244cfaf65b92.png" /></p>

<p align="center"><strong>After</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54867233-28f6ed00-4d7e-11e9-9a65-ef12a61203f9.png" /></p>
