### PR TITLE
Background color of inactive keyboard focused list items

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -116,6 +116,7 @@
     "list.activeSelectionForeground": "#2e3440",
     "list.inactiveSelectionBackground": "#434c5e",
     "list.inactiveSelectionForeground": "#d8dee9",
+    "list.inactiveFocusBackground": "#434c5ecc",
     "list.hoverForeground": "#eceff4",
     "list.focusForeground": "#d8dee9",
     "list.focusBackground": "#88c0d099",


### PR DESCRIPTION
> Resolves #107

When navigating the file explorer list with the keyboard and moving the focus to another UI component (like the editor) the background color of the selected item is colorized with the `list.inactiveFocusBackground`
theme key.
It has been set to `nord2` with a opacity of 80% to match the style of inactive list items that were focused without the keyboard (`list.inactiveSelectionBackground`).

<p align="center"><strong>Before</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54876811-74f57080-4e16-11e9-9a21-119837740a33.png" /></p>

<p align="center"><strong>After</strong><br /><img src="https://user-images.githubusercontent.com/7836623/54876810-74f57080-4e16-11e9-94f2-32b641288b54.png" /></p>
