### PR TITLE
Comment Color Brightness

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -262,7 +262,7 @@
       "name": "Comment",
       "scope": "comment",
       "settings": {
-        "foreground": "#4C566A"
+        "foreground": "#616E88"
       }
     },
     {
@@ -441,7 +441,7 @@
         "punctuation.start.definition.comment"
       ],
       "settings": {
-        "foreground": "#4C566A"
+        "foreground": "#616E88"
       }
     },
     {
@@ -768,7 +768,7 @@
         "source.java punctuation.definition.tag.end.javadoc"
       ],
       "settings": {
-        "foreground": "#4C566A"
+        "foreground": "#616E88"
       }
     },
     {
@@ -989,7 +989,7 @@
       "name": "[Markdown] Markup Quote Punctuation Definition",
       "scope": "text.html.markdown markup.quote",
       "settings": {
-        "foreground": "#4C566A"
+        "foreground": "#616E88"
       }
     },
     {


### PR DESCRIPTION
> Bound to https://github.com/arcticicestudio/nord/issues/94
> Resolves #117

This issue will implement the increase of the comment color (`nord3`) brightness by 10% from a lightness level of ~35% to ~45%.

➜ Please see https://github.com/arcticicestudio/nord/issues/94 for all details about this design change decision.

#### Before

![gh-146-before](https://user-images.githubusercontent.com/7836623/54902736-76886c80-4eda-11e9-86cd-dfc935aff5e3.png)
![gh-145-before-2](https://user-images.githubusercontent.com/7836623/54902735-76886c80-4eda-11e9-9aa0-41ded647bdb2.png)

#### After

![gh-146-preview](https://user-images.githubusercontent.com/7836623/54902766-856f1f00-4eda-11e9-897a-9b0971586a0b.png)
![gh-145-preview-2](https://user-images.githubusercontent.com/7836623/54902765-856f1f00-4eda-11e9-9d09-50c89faece43.png)
