### PR TITLE
Add color for `tree.indentGuidesStroke`

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -233,6 +233,7 @@
     "titleBar.border": "#2e344000",
     "titleBar.inactiveBackground": "#2e3440",
     "titleBar.inactiveForeground": "#d8dee966",
+    "tree.indentGuidesStroke": "#616e88",
     "walkThrough.embeddedEditorBackground": "#2e3440",
     "welcomePage.buttonBackground": "#434c5e",
     "welcomePage.buttonHoverBackground": "#4c566a",


### PR DESCRIPTION
> Resolves #145 

[VS Code 1.36.0][v] (June 2019) introduced [support for indent guide lines in the tree view][igl]. To adapt to Nord's style and ensure it is still distinguishable from the background when hovering with the mouse, the
new brightened comment color based on ` nord3` (#118) is used.

<p align="center"><strong>Before</strong></p>
<p align="center"><img width="60%" src="https://user-images.githubusercontent.com/7836623/61582804-c0532d80-ab2f-11e9-9626-9c95610f0d09.png" /></p>

<p align="center"><strong>After</strong></p>
<p align="center"><img width="60%" src="https://user-images.githubusercontent.com/7836623/61582803-c0532d80-ab2f-11e9-92e4-b801f60092f6.png" /></p>

[v]: https://code.visualstudio.com/updates/v1_36
[igl]: https://code.visualstudio.com/updates/v1_36#_tree-indent-guides