### PR TITLE
`textCodeBlock.background` workbench theme key

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -230,6 +230,7 @@
     "terminal.ansiBrightMagenta": "#b48ead",
     "terminal.ansiBrightCyan": "#8fbcbb",
     "terminal.ansiBrightWhite": "#eceff4",
+    "textCodeBlock.background": "#4c566a",
     "titleBar.activeBackground": "#2e3440",
     "titleBar.activeForeground": "#d8dee9",
     "titleBar.border": "#2e344000",


### PR DESCRIPTION
Closes #155 

Added the `textCodeBlock.background` workbench theme key that is used by VS Code features like the [IntelliSense _quick info_][is] to style the background color of code blocks in the documentation text. By default this uses a very dark color.
This PR changes the color to use `nord3` instead.

<img src="https://user-images.githubusercontent.com/7836623/66107330-483dc500-e5c0-11e9-9482-2dc648019b7c.png">

<img src="https://user-images.githubusercontent.com/7836623/66107331-48d65b80-e5c0-11e9-842c-31d8a01daf36.png">


[is]: https://code.visualstudio.com/docs/editor/intellisense