### PR TITLE
`descriptionForeground` workbench theme key

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -17,6 +17,7 @@
     "debugExceptionWidget.background": "#4c566a",
     "debugExceptionWidget.border": "#2e3440",
     "debugToolBar.background": "#3b4252",
+    "descriptionForeground": "#d8dee9e6",
     "diffEditor.insertedTextBackground": "#81a1c133",
     "diffEditor.removedTextBackground": "#bf616a4d",
     "dropdown.background": "#3b4252",


### PR DESCRIPTION
Resolves #160 

This PR adds the `descriptionForeground` workbench theme key that was introduced almost 2 years ago in [microsoft/vscode@f450e0b1fe3][c] for https://github.com/microsoft/vscode/issues/26298, but not mentioned in a changelog so there was no support for it in Nord.
It now uses `nord4` with a opacity of 90% as color value (`#d8dee9e6`).

[c]: https://github.com/microsoft/vscode/blame/f450e0b1fe3ac26ce6bf8367ff1bd60fb1387a7d/src/vs/platform/theme/common/colorRegistry.ts#L154