### PR TITLE
Syntax highlighting for Elixir module names and atoms

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -695,6 +695,36 @@
       }
     },
     {
+      "name": "[Elixir] module names",
+      "scope": "entity.name.type.module.elixir",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Elixir] module attributes",
+      "scope": "variable.other.readwrite.module.elixir",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Elixir] atoms",
+      "scope": "constant.other.symbol.elixir",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Elixir] modules",
+      "scope": "variable.other.constant.elixir",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
       "name": "[Go] String Format Placeholder",
       "scope": "source.go constant.other.placeholder.go",
       "settings": {

--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -695,14 +695,14 @@
       }
     },
     {
-      "name": "[Elixir] module names",
+      "name": "[Elixir](JakeBecker.elixir-ls) module names",
       "scope": "entity.name.type.module.elixir",
       "settings": {
         "foreground": "#8FBCBB"
       }
     },
     {
-      "name": "[Elixir] module attributes",
+      "name": "[Elixir](JakeBecker.elixir-ls) module attributes",
       "scope": "variable.other.readwrite.module.elixir",
       "settings": {
         "foreground": "#D8DEE9",
@@ -710,7 +710,7 @@
       }
     },
     {
-      "name": "[Elixir] atoms",
+      "name": "[Elixir](JakeBecker.elixir-ls) atoms",
       "scope": "constant.other.symbol.elixir",
       "settings": {
         "foreground": "#D8DEE9",
@@ -718,7 +718,7 @@
       }
     },
     {
-      "name": "[Elixir] modules",
+      "name": "[Elixir](JakeBecker.elixir-ls) modules",
       "scope": "variable.other.constant.elixir",
       "settings": {
         "foreground": "#8FBCBB"


### PR DESCRIPTION
Closes: https://github.com/arcticicestudio/nord-visual-studio-code/issues/165

Improve Elixir support adding syntax highlight to atoms and module names using `vscode-elixir-lis` patterns.

References:
https://github.com/JakeBecker/vscode-elixir-ls
https://github.com/JakeBecker/vscode-elixir-ls/blob/master/syntaxes/elixir.json