### PR TITLE
fix npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@arcticicestudio/eslint-config-base": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@arcticicestudio/eslint-config-base/-/eslint-config-base-0.8.0.tgz",
+      "integrity": "sha512-jAYEbzXV8in6jj7Rg+HLKwzdo4xDSLrZtaQYweiPIGNqFseEI+0CNx0hwFNywlusLuOPnOQypwKGDjQhbUCPyQ==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.8"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -761,6 +770,12 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "dev": true
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -1126,15 +1141,6 @@
         }
       }
     },
-    "eslint-config-arcticicestudio-base": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-arcticicestudio-base/-/eslint-config-arcticicestudio-base-0.5.0.tgz",
-      "integrity": "sha512-ZBivV5FvzTEZTXeF+Ho7rUhEXf2O5BXFAchNZipoYhySnTrndPAoH0ixdYgJzlH6I702OJyNZWRwdF0Cqzad3A==",
-      "dev": true,
-      "requires": {
-        "eslint-restricted-globals": "^0.1.1"
-      }
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -1315,12 +1321,6 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
-    },
-    "eslint-restricted-globals": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
-      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
-      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
     "package": "vsce package --out nord-visual-studio-code.vsix"
   },
   "devDependencies": {
+    "@arcticicestudio/eslint-config-base": ">=0.5.0 <1.0.0",
     "babel-eslint": "10.0.1",
     "del-cli": "1.1.0",
     "eslint": "5.16.0",
-    "eslint-config-arcticicestudio-base": ">=0.5.0 <1.0.0",
     "eslint-plugin-import": "2.17.3",
     "eslint-plugin-json": "1.4.0",
     "eslint-plugin-prettier": "3.1.0",


### PR DESCRIPTION
* switch to [`@arcticicestudio/eslint-config-base`](https://www.npmjs.com/package/@arcticicestudio/eslint-config-base) in dependencies

Seems `eslint-config-arcticicestudio-base` was removed from the npm registry breaking all installations of this project, either locally or when added as a dependency in `package.json`. This PR switches to the `@arcticicestudio/eslint-config-base` package to fix that.