### PR TITLE
Invalid quick input list background for focused state

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -220,7 +220,7 @@
     "pickerGroup.border": "#3b4252",
     "pickerGroup.foreground": "#88c0d0",
     "progressBar.background": "#88c0d0",
-    "quickInputList.focusBackground": "#88c0d099",
+    "quickInputList.focusBackground": "#88c0d0",
     "quickInputList.focusForeground": "#2e3440",
     "sash.hoverBorder": "#88c0d0",
     "scrollbar.shadow": "#00000066",


### PR DESCRIPTION
Fixes #219
Related to #215

<h3 align="center">Before</h3>
<div align="center">
  <img src="https://user-images.githubusercontent.com/7836623/123047579-bdd56e80-d3fd-11eb-9467-faa1275d50f3.png" width="75%" />
</div>

<h3 align="center">After</h3>
<div align="center">
  <img src="https://user-images.githubusercontent.com/7836623/122639074-1522c880-d0f8-11eb-9e9e-ac5acd219e99.png" width="75%" />
</div>

