### PR TITLE
TextMate rules for Markdown math formula syntax highlighting

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -1096,6 +1096,37 @@
       }
     },
     {
+      "name": "[Markdown] Markup Math Constant",
+      "scope": "text.html.markdown constant.character.math.tex",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Definition Marker",
+      "scope": [
+        "text.html.markdown punctuation.definition.math.begin",
+        "text.html.markdown punctuation.definition.math.end"
+      ],
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Function Definition Marker",
+      "scope": "text.html.markdown punctuation.definition.function.math.tex",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Operator",
+      "scope": "text.html.markdown punctuation.math.operator.latex",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
       "name": "[Markdown] Punctuation Definition Heading",
       "scope": "text.html.markdown punctuation.definition.heading",
       "settings": {


### PR DESCRIPTION
Resolves #221 

<h3 align="center">Before</h3>
<div align="center">
  <img src="https://user-images.githubusercontent.com/7836623/125685322-3fd170ae-8927-44e3-ab3e-bd5e062cc1de.png" width="75%" />
</div>

<h3 align="center">After</h3>
<div align="center">
  <img src="https://user-images.githubusercontent.com/7836623/125685315-d03b4719-4957-44c5-bb1e-674889a063cc.png" width="75%" />
</div>