### PR TITLE
Color token for active terminal tab indicator

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -281,6 +281,7 @@
     "terminal.ansiBrightMagenta": "#b48ead",
     "terminal.ansiBrightCyan": "#8fbcbb",
     "terminal.ansiBrightWhite": "#eceff4",
+    "terminal.tab.activeBorder": "#88c0d0",
     "textBlockQuote.background": "#3b4252",
     "textBlockQuote.border": "#81a1c1",
     "textCodeBlock.background": "#4c566a",


### PR DESCRIPTION
Resolves #226 

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/133668853-53f5b563-3bdb-4fd4-830f-02734c2efd14.png" />
</div>

<div align="center">
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/133668851-4d0f7e1a-2f68-459e-ba4e-4c7ba270ea12.png"/>
</div>
