### PR TITLE
Color tokens for TypeScript and JavaScript inlay hints

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -48,6 +48,8 @@
     "editorHint.foreground": "#ebcb8b",
     "editorIndentGuide.background": "#434c5eb3",
     "editorIndentGuide.activeBackground": "#4c566a",
+    "editorInlayHint.background": "#434c5e",
+    "editorInlayHint.foreground": "#d8dee9",
     "editorLineNumber.foreground": "#4c566a",
     "editorLineNumber.activeForeground": "#d8dee9",
     "editorWhitespace.foreground": "#4c566ab3",


### PR DESCRIPTION
Resolves #224

[VS Code 1.60][1] (August 2021) introduced [inlay hints for JavaScript and TypeScript][2] (opt-in via `editor.inlayHints.enabled`), including new color tokens to customize their appereance. They have been added and adjusted to match Nord's theme style:

- `editorInlayHint.background` — the background color used for inline hint boxes.
- `editorInlayHint.foreground` — the foreground color used for inline hint boxes.

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/134240461-943cc2d8-286a-45be-8701-841f7bccedf6.png" />
</div>

<div align="center">
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/134240448-88802d32-ed01-4166-8b4c-b6ac146f00d0.png"/>
</div>

[1]: https://code.visualstudio.com/updates/v1_60
[2]: https://code.visualstudio.com/updates/v1_60#_inlay-hints-for-javascript-and-typescript
