### PR TITLE
Improved syntax highlighting support for Rust

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -1216,6 +1216,46 @@
       }
     },
     {
+      "name": "[Rust] Entity types",
+      "scope": "source.rust entity.name.type",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Rust] Macro",
+      "scope": "source.rust meta.macro entity.name.function",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Rust] Attributes",
+      "scope": [
+        "source.rust meta.attribute",
+        "source.rust meta.attribute punctuation",
+        "source.rust meta.attribute keyword.operator"
+      ],
+      "settings": {
+        "foreground": "#5E81AC",
+      }
+    },
+    {
+      "name": "[Rust] Traits",
+      "scope": "source.rust entity.name.type.trait",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Rust] Interpolation Bracket Curly",
+      "scope": "source.rust punctuation.definition.interpolation",
+      "settings": {
+        "foreground": "#EBCB8B",
+      }
+    },
+    {
       "name": "[SCSS] Punctuation Definition Interpolation Bracket Curly",
       "scope": [
         "source.css.scss punctuation.definition.interpolation.begin.bracket.curly",


### PR DESCRIPTION
Resolves #167 

Improved syntax highlighting support for Rust.

1. Entity types are colorised with `#8FBCBB`;
2. Macros are colorised with `#88C0D0` and bold font to make them visually different from "normal" functions.
3. Attributes and derives are colored with `#5E81AC`.
4. Interpolation brackets are colored with `#A3BE8C` to meet whole string color. ( Not sure about this one, in TS they are different, but in a Vim theme, they are equal for Rust language )
5. As a result of 1, import statements and paths are better colored with keyword and type colors.

<p align="center"><b>Before</b></p>

![Screenshot 2021-12-23 at 15 46 51](https://user-images.githubusercontent.com/56257437/147250231-a8d31d41-e24c-4908-a0a5-4afa99515f57.png)

<p align="center"><b>After</b></p>

![Screenshot 2021-12-23 at 15 46 17](https://user-images.githubusercontent.com/56257437/147250241-fa0adda0-4d37-4c8a-883a-6462529e38e4.png)

