### PR TITLE
Improved  syntax highlighting for GraphQL

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -1348,6 +1348,20 @@
       "settings": {
         "foreground": "#8FBCBB"
       }
+    },
+    {
+      "name": "[GraphQL] Variable",
+      "scope": "source.graphql meta.arguments",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[GraphQL] Selectionset",
+      "scope": "source.graphql meta.selectionset",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
     }
   ]
 }


### PR DESCRIPTION
Improved syntax highlighting support for GraphQL.

1. Variables are colorised with  `#D8DEE9`
2. Selectionset are colorised with  `#8FBCBB`

**<div align="center">Before</div>**
![graphql-before](https://user-images.githubusercontent.com/1382368/147831400-056e39dd-ad1f-4b8a-bf11-5de8bbde9079.png)
**<div align="center">After</div>**
![graphql-after](https://user-images.githubusercontent.com/1382368/147831401-f769166d-f385-41a5-a755-573f78696598.png)
