### PR TITLE
Improve shell highlighting variables

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -1348,6 +1348,17 @@
       "settings": {
         "foreground": "#8FBCBB"
       }
+    },
+    {
+      "name": "[Shell] Variables",
+      "scope": [
+        "source.shell variable.other",
+        "source.shell punctuation.definition.variable",
+        "source.makefile variable.other"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
     }
   ]
 }


### PR DESCRIPTION
Just change Variables color with  `#8FBCBB` to improve readability with path and commands

**<div align="center">Before</div>**
![bash-before](https://user-images.githubusercontent.com/1382368/147832523-1569d516-28b9-4ad1-a1bd-2eac4200eec6.png)
**<div align="center">After</div>**
![bash-after](https://user-images.githubusercontent.com/1382368/147832526-56362252-9e2f-4a2e-8724-3a6d21c34f91.png)

