### PR TITLE
Fix vsce package errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
   <a href="https://www.nordtheme.com/ports/visual-studio-code" target="_blank">
     <picture>
       <source srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-      <img srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" />
+      <img src="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" />
     </picture>
   </a>
 </p>

--- a/package.json
+++ b/package.json
@@ -41,17 +41,17 @@
   ],
   "badges": [
     {
-      "url": "https://vsmarketplacebadge.apphb.com/version/arcticicestudio.nord-visual-studio-code.svg",
+      "url": "https://img.shields.io/visual-studio-marketplace/v/arcticicestudio.nord-visual-studio-code",
       "href": "https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code",
       "description": "Extension version"
     },
     {
-      "url": "https://vsmarketplacebadge.apphb.com/installs/arcticicestudio.nord-visual-studio-code.svg",
+      "url": "https://img.shields.io/visual-studio-marketplace/i/arcticicestudio.nord-visual-studio-code",
       "href": "https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code",
       "description": "Extension installs"
     },
     {
-      "url": "https://vsmarketplacebadge.apphb.com/rating/arcticicestudio.nord-visual-studio-code.svg",
+      "url": "https://img.shields.io/visual-studio-marketplace/r/arcticicestudio.nord-visual-studio-code",
       "href": "https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code",
       "description": "Extension Rating"
     }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
   <a href="https://www.nordtheme.com/ports/visual-studio-code" target="_blank">
     <picture>
       <source srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-      <img srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" />
+      <img src="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero.png" srcset="https://raw.githubusercontent.com/nordtheme/web/main/assets/images/ports/visual-studio-code/repository-hero-2x.png 2x" width="100%" />
     </picture>
   </a>
 </p>
@@ -21,13 +21,13 @@
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code" target="_blank">
-    <img src="https://vsmarketplacebadge.apphb.com/version/arcticicestudio.nord-visual-studio-code.svg?style=flat-square&label=Extension%20Marketplace&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
+    <img src="https://img.shields.io/visual-studio-marketplace/v/arcticicestudio.nord-visual-studio-code?style=flat-square&label=Installations&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
   </a>
   <a href="https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code" target="_blank">
-    <img src="https://vsmarketplacebadge.apphb.com/installs/arcticicestudio.nord-visual-studio-code.svg?style=flat-square&label=Installations&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
+    <img src="https://img.shields.io/visual-studio-marketplace/i/arcticicestudio.nord-visual-studio-code?style=flat-square&label=Installations&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
   </a>
   <a href="https://marketplace.visualstudio.com/items/arcticicestudio.nord-visual-studio-code" target="_blank">
-    <img src="https://vsmarketplacebadge.apphb.com/rating-short/arcticicestudio.nord-visual-studio-code.svg?style=flat-square&label=Rating&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
+    <img src="https://img.shields.io/visual-studio-marketplace/r/arcticicestudio.nord-visual-studio-code?style=flat-square&label=Rating&logo=visual-studio-code&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/>
   </a>
 </p>
 


### PR DESCRIPTION
This PR fixes errors that occur when running `vsce package` with the latest `vsce` (2.19.0).

- Include a `src` attribute to `img` tags ([ref](https://github.com/microsoft/vscode-vsce/blob/701a450041c6c65247196ddcd8524946cf917656/src/package.ts#L826C4-L826C4))
- Use Shields.io for marketplace badges ([ref](https://github.com/cssho/VSMarketplaceBadge/issues/18))