### PR TITLE
Add color bindings for Jupyter Notebooks

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -185,6 +185,10 @@
     "minimapSlider.activeBackground": "#434c5eaa",
     "minimapSlider.background": "#434c5e99",
     "minimapSlider.hoverBackground": "#434c5eaa",
+    "notebook.outputContainerBackgroundColor": "#4c566a",
+    "notebook.editorBackground": "#3b4252",
+    "notebook.focusedCellBorder": "#88c0d0",
+    "notebook.focusedEditorBorder": "#a3be8c",
 
     /* `notification.*` keys are legacy support for VS Code versions >1.21.0 */
     "notification.background": "#3b4252",


### PR DESCRIPTION
Without color differentiation, the notebook view in VS code is very difficult to use. This PR applies the Nord color scheme to notebook UI elements.

There are many notebook UI elements we could bind to (API reference <https://code.visualstudio.com/api/references/theme-color#notebook-colors>), but this hits the major elements. 

# Before
![image](https://github.com/nordtheme/visual-studio-code/assets/10763333/3544ec60-128c-4a2c-a454-b4f4b38bfc30)

# After
![image](https://github.com/nordtheme/visual-studio-code/assets/10763333/d87f1285-63d2-4a0c-9d06-1050f4d73ae0)

