### PR TITLE
increase editorGroup.border contrast

### DIFF
--- a/themes/nord-color-theme.json
+++ b/themes/nord-color-theme.json
@@ -88,7 +88,7 @@
     "editorBracketHighlight.unexpectedBracket.foreground": "#bf616a",
     "editorCodeLens.foreground": "#4c566a",
     "editorGroup.background": "#2e3440",
-    "editorGroup.border": "#3b425201",
+    "editorGroup.border": "#3b4252",
     "editorGroup.dropBackground": "#3b425299",
     "editorGroupHeader.border": "#3b425200",
     "editorGroupHeader.noTabsBackground": "#2e3440",


### PR DESCRIPTION
remove alpha channel of editorGroup.border

0x01 / 0xff = 0.003921 alpha make split editor border almost invisible.
For user that split editor and resize both sides, I request to increase contrast of that.